### PR TITLE
Add Keycloak style access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The issuer in the generated API tokens and the address of the GDPR API Tester. T
 
 ### ISSUER_TYPE
 
-The type of the issuer (authorizaton server) that the GDPR API Tester simulates. Allowed values are "tunnistamo" and "keycloak".
+The type of the issuer (authorizaton server) that the GDPR API Tester simulates. The type affects the contents of the generated access tokens. Allowed values are "tunnistamo" and "keycloak".
 
 ### GDPR_API_AUDIENCE
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Following is a list of all the configuration options:
 
 The issuer in the generated API tokens and the address of the GDPR API Tester. The API must have connectivity to this address because the JWT token verification will fetch the public key from here.
 
+### ISSUER_TYPE
+
+The type of the issuer (authorizaton server) that the GDPR API Tester simulates. Allowed values are "tunnistamo" and "keycloak".
+
 ### GDPR_API_AUDIENCE
 
 The audience in the generated API tokens. i.e. The client id of the GDPR API.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ but it's included for completeness' sake.
 The tool starts as an interactive prompt the user can use to run commands.
 
 > Commands:
-> 
+>
 >  help - This help\
 >  config - Show configuration\
 >  keys - Print public and private keys used in the OIDC Simulator\
@@ -174,16 +174,16 @@ docker run -it -p 8000:8000 --env-file config.env example-backend
 
 See the [Running using Docker](#running-using-docker) section and set the following values in the configuration:
 
-    ISSUER=http://host.docker.internal:8888/                           
-    GDPR_API_AUDIENCE=http://example.com/exampleapi                               
-    GDPR_API_AUTHORIZATION_FIELD=http://example.com                                          
-    GDPR_API_QUERY_SCOPE=exampleapi.gdprquery                                        
-    GDPR_API_DELETE_SCOPE=exampleapi.gdprdelete                                       
+    ISSUER=http://host.docker.internal:8888/
+    GDPR_API_AUDIENCE=http://example.com/exampleapi
+    GDPR_API_AUTHORIZATION_FIELD=http://example.com
+    GDPR_API_QUERY_SCOPE=exampleapi.gdprquery
+    GDPR_API_DELETE_SCOPE=exampleapi.gdprdelete
     GDPR_API_URL=http://host.docker.internal:8000/gdpr-api/v1/user/$user_uuid
-    PROFILE_ID=65d4015d-1736-4848-9466-25d43a1fe8c7                        
-    USER_UUID=9e14df7c-81f6-4c41-8578-6aa7b9d0e5c0                        
-    LOA=substantial                                                 
-    SID=00000000-0000-4000-9000-000000000001                        
+    PROFILE_ID=65d4015d-1736-4848-9466-25d43a1fe8c7
+    USER_UUID=9e14df7c-81f6-4c41-8578-6aa7b9d0e5c0
+    LOA=substantial
+    SID=00000000-0000-4000-9000-000000000001
 
 You should be able to send requests to the example backend after the GDPR API Tester starts. e.g. issuing the "query" command should yield something like this:
 
@@ -264,7 +264,7 @@ sequenceDiagram
     actor User
     participant Profile UI
     participant Profile Backend
-    participant Service GDPR API 
+    participant Service GDPR API
     participant Tunnistamo
     User->>+Profile UI: Download my data
     Profile UI->>+Profile Backend: Get data
@@ -284,8 +284,8 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     actor Tester
-    participant GDPR API Tester 
-    participant Service GDPR API 
+    participant GDPR API Tester
+    participant Service GDPR API
     GDPR API Tester->>GDPR API Tester: Generate RSA key
     Tester->>+GDPR API Tester: query
     GDPR API Tester->>GDPR API Tester: Generate API token

--- a/env.example
+++ b/env.example
@@ -5,6 +5,7 @@
 ISSUER=http://127.0.0.1:8888/
 
 # The type of the issuer (authorizaton server) that the GDPR API Tester simulates.
+# The type affects the contents of the generated access tokens.
 # Allowed values are "tunnistamo" and "keycloak".
 ISSUER_TYPE=keycloak
 
@@ -18,10 +19,16 @@ GDPR_API_AUTHORIZATION_FIELD=http://localhost:8080
 
 # The GDPR query scope
 #   e.g. exampleapi.gdprquery
+# When issuer type is Keycloak, only the part after the last dot is used.
+# This makes for example the value `exampleapi.gdprquery` work
+# correctly in every case.
 GDPR_API_QUERY_SCOPE=exampleapi.gdprquery
 
 # The GDPR delete scope
 #   e.g. exampleapi.gdprdelete
+# When issuer type is Keycloak, only the part after the last dot is used.
+# This makes for example the value `exampleapi.gdprdelete` work
+# correctly in every case.
 GDPR_API_DELETE_SCOPE=exampleapi.gdprdelete
 
 # The address of the GDPR API

--- a/env.example
+++ b/env.example
@@ -4,6 +4,10 @@
 #   verification will fetch the public key from here.
 ISSUER=http://127.0.0.1:8888/
 
+# The type of the issuer (authorizaton server) that the GDPR API Tester simulates.
+# Allowed values are "tunnistamo" and "keycloak".
+ISSUER_TYPE=keycloak
+
 # The audience in the generated API tokens and the client id of the GDPR API
 #   e.g. http://localhost:8080/exampleapi
 GDPR_API_AUDIENCE=http://localhost:8080/exampleapi

--- a/gdpr_api_tester/config.py
+++ b/gdpr_api_tester/config.py
@@ -68,7 +68,13 @@ class AppConfig:
                     "The configuration field \"{}\" is required".format(field)
                 )
 
-            self.__setattr__(field, env.get(field, default_value))
+            self.set_config(field, env.get(field, default_value))
+
+    def set_config(self, name, value):
+        if name not in self.get_keys():
+            raise ValueError('Unknown config key: "{}"'.format(name))
+
+        self.__setattr__(name, value)
 
     def __str__(self):
         result = "Configuration:\n"

--- a/gdpr_api_tester/config.py
+++ b/gdpr_api_tester/config.py
@@ -29,6 +29,7 @@ class AppConfig:
     ISSUER: str
 
     # The type of the issuer (authorizaton server) that the GDPR API Tester simulates.
+    # The type affects the contents of the generated access tokens.
     # Allowed values are "tunnistamo" and "keycloak".
     ISSUER_TYPE: IssuerType = IssuerType.TUNNISTAMO
 
@@ -42,10 +43,16 @@ class AppConfig:
 
     # The GDPR query scope
     #   e.g. exampleapi.gdprquery
+    # When issuer type is Keycloak, only the part after the last dot is used.
+    # This makes for example the value `exampleapi.gdprquery` work
+    # correctly in every case.
     GDPR_API_QUERY_SCOPE: str
 
     # The GDPR delete scope
     #   e.g. exampleapi.gdprdelete
+    # When issuer type is Keycloak, only the part after the last dot is used.
+    # This makes for example the value `exampleapi.gdprdelete` work
+    # correctly in every case.
     GDPR_API_DELETE_SCOPE: str
 
     # The address of the GDPR API

--- a/gdpr_api_tester/config.py
+++ b/gdpr_api_tester/config.py
@@ -74,7 +74,9 @@ class AppConfig:
         if name not in self.get_keys():
             raise ValueError('Unknown config key: "{}"'.format(name))
 
-        self.__setattr__(name, value)
+        typ = self.__annotations__[name]
+
+        self.__setattr__(name, typ(value))
 
     def __str__(self):
         result = "Configuration:\n"

--- a/gdpr_api_tester/config.py
+++ b/gdpr_api_tester/config.py
@@ -1,6 +1,16 @@
 import os
 
+from enum import Enum
+
 from dotenv import find_dotenv, load_dotenv
+
+class IssuerType(Enum):
+    TUNNISTAMO = "tunnistamo"
+    KEYCLOAK = "keycloak"
+
+    def __str__(self) -> str:
+        return self.value
+
 
 # Find the dotenv path by using the current directory
 #
@@ -17,6 +27,10 @@ class AppConfig:
     #   The API must have connectivity to this address because the JWT token
     #   verification will fetch the public key from here.
     ISSUER: str
+
+    # The type of the issuer (authorizaton server) that the GDPR API Tester simulates.
+    # Allowed values are "tunnistamo" and "keycloak".
+    ISSUER_TYPE: IssuerType = IssuerType.TUNNISTAMO
 
     # The audience in the generated API tokens and the client id of the GDPR API
     #   e.g. http://localhost:8080/exampleapi

--- a/gdpr_api_tester/main.py
+++ b/gdpr_api_tester/main.py
@@ -320,13 +320,13 @@ async def read_command():
             if arguments:
                 matches = re.match(r"(?P<key>\w+)\s*=\s*(?P<value>.*)", arguments)
                 if matches:
-                    if matches["key"] in app_config.get_keys():
+                    try:
+                        app_config.set_config(matches["key"], matches["value"])
                         await aprint(
                             "Set config", matches["key"], "value to", matches["value"]
                         )
-                        setattr(app_config, matches["key"], matches["value"])
-                    else:
-                        await aprint('Unknown config key: "{}"'.format(matches["key"]))
+                    except Exception as e:
+                        await aprint(str(e))
             else:
                 await aprint("set command needs arguments")
         else:


### PR DESCRIPTION
Add an issuer type configuration option, that can be used to change between Tunnistamo and Keycloak. The setting affects how scopes look in the generated access tokens.